### PR TITLE
Revert "fix: orig.tar contains debian/ directory"

### DIFF
--- a/TarSCM/archive.py
+++ b/TarSCM/archive.py
@@ -262,10 +262,6 @@ class Gbp(BaseArchive):
             logging.info("removing gbp.conf")
             os.remove(scm_object.clone_dir + "/debian/gbp.conf")
 
-        # ignore debian directory
-        with open(scm_object.clone_dir + ".git/info/attributes", "a+") as f
-            f.write("debian/ export-ignore\n")
-
         #upstreamversion = version.split('-')[0]
         upstreamversion_end = version.rfind('-')
         upstreamversion = version[:upstreamversion_end]


### PR DESCRIPTION
some bugs
Reverts linuxdeepin/obs-service-tar_scm#2